### PR TITLE
Add rama convergence layer proof of concept

### DIFF
--- a/common/config/include/InductsConfig.h
+++ b/common/config/include/InductsConfig.h
@@ -40,6 +40,9 @@ struct induct_element_config_t {
     uint32_t numRxCircularBufferElements;
     uint32_t numRxCircularBufferBytesPerElement;
 
+    //specific to rama
+    uint8_t ramaHeaderByte;
+
     //specific to bp over encap
     std::string bpEncapLocalSocketOrPipePath;
 

--- a/common/config/include/OutductsConfig.h
+++ b/common/config/include/OutductsConfig.h
@@ -68,6 +68,9 @@ struct outduct_element_config_t {
     //specific to udp and ltp
     uint64_t rateLimitPrecisionMicroSec;
 
+    //specific to rama
+    uint8_t ramaHeaderByte;
+
     //specific to slip over uart
     std::string comPort;
     uint32_t baudRate;

--- a/common/config/src/InductsConfig.cpp
+++ b/common/config/src/InductsConfig.cpp
@@ -25,17 +25,19 @@ static constexpr hdtn::Logger::SubProcess subprocess = hdtn::Logger::SubProcess:
 
 static const std::vector<std::string> VALID_CONVERGENCE_LAYER_NAMES = {
     "ltp_over_udp", "ltp_over_ipc", "ltp_over_encap_local_stream", "bp_over_encap_local_stream",
-    "udp", "stcp", "tcpcl_v3", "tcpcl_v4", "slip_over_uart"
+    "udp", "stcp", "tcpcl_v3", "tcpcl_v4", "slip_over_uart", "rama"
 };
 
 induct_element_config_t::induct_element_config_t() :
     name(""),
     convergenceLayer(""),
     boundPort(0),
-    numRxCircularBufferElements(0),
-    numRxCircularBufferBytesPerElement(0),
+      numRxCircularBufferElements(0),
+      numRxCircularBufferBytesPerElement(0),
 
-    bpEncapLocalSocketOrPipePath(""),
+      ramaHeaderByte(0xA0),
+
+      bpEncapLocalSocketOrPipePath(""),
 
     thisLtpEngineId(0),
     remoteLtpEngineId(0),
@@ -80,10 +82,12 @@ induct_element_config_t::induct_element_config_t(const induct_element_config_t& 
     name(o.name),
     convergenceLayer(o.convergenceLayer),
     boundPort(o.boundPort),
-    numRxCircularBufferElements(o.numRxCircularBufferElements),
-    numRxCircularBufferBytesPerElement(o.numRxCircularBufferBytesPerElement),
+      numRxCircularBufferElements(o.numRxCircularBufferElements),
+      numRxCircularBufferBytesPerElement(o.numRxCircularBufferBytesPerElement),
 
-    bpEncapLocalSocketOrPipePath(o.bpEncapLocalSocketOrPipePath),
+      ramaHeaderByte(o.ramaHeaderByte),
+
+      bpEncapLocalSocketOrPipePath(o.bpEncapLocalSocketOrPipePath),
 
     thisLtpEngineId(o.thisLtpEngineId),
     remoteLtpEngineId(o.remoteLtpEngineId),
@@ -125,10 +129,12 @@ induct_element_config_t::induct_element_config_t(induct_element_config_t&& o) no
     name(std::move(o.name)),
     convergenceLayer(std::move(o.convergenceLayer)),
     boundPort(o.boundPort),
-    numRxCircularBufferElements(o.numRxCircularBufferElements),
-    numRxCircularBufferBytesPerElement(o.numRxCircularBufferBytesPerElement),
+      numRxCircularBufferElements(o.numRxCircularBufferElements),
+      numRxCircularBufferBytesPerElement(o.numRxCircularBufferBytesPerElement),
 
-    bpEncapLocalSocketOrPipePath(std::move(o.bpEncapLocalSocketOrPipePath)),
+      ramaHeaderByte(o.ramaHeaderByte),
+
+      bpEncapLocalSocketOrPipePath(std::move(o.bpEncapLocalSocketOrPipePath)),
 
     thisLtpEngineId(o.thisLtpEngineId),
     remoteLtpEngineId(o.remoteLtpEngineId),
@@ -171,9 +177,11 @@ induct_element_config_t& induct_element_config_t::operator=(const induct_element
     convergenceLayer = o.convergenceLayer;
     boundPort = o.boundPort;
     numRxCircularBufferElements = o.numRxCircularBufferElements;
-    numRxCircularBufferBytesPerElement = o.numRxCircularBufferBytesPerElement;
+      numRxCircularBufferBytesPerElement = o.numRxCircularBufferBytesPerElement;
 
-    bpEncapLocalSocketOrPipePath = o.bpEncapLocalSocketOrPipePath;
+      ramaHeaderByte = o.ramaHeaderByte;
+
+      bpEncapLocalSocketOrPipePath = o.bpEncapLocalSocketOrPipePath;
 
     thisLtpEngineId = o.thisLtpEngineId;
     remoteLtpEngineId = o.remoteLtpEngineId;
@@ -218,9 +226,11 @@ induct_element_config_t& induct_element_config_t::operator=(induct_element_confi
     convergenceLayer = std::move(o.convergenceLayer);
     boundPort = o.boundPort;
     numRxCircularBufferElements = o.numRxCircularBufferElements;
-    numRxCircularBufferBytesPerElement = o.numRxCircularBufferBytesPerElement;
+      numRxCircularBufferBytesPerElement = o.numRxCircularBufferBytesPerElement;
 
-    bpEncapLocalSocketOrPipePath = std::move(o.bpEncapLocalSocketOrPipePath);
+      ramaHeaderByte = o.ramaHeaderByte;
+
+      bpEncapLocalSocketOrPipePath = std::move(o.bpEncapLocalSocketOrPipePath);
 
     thisLtpEngineId = o.thisLtpEngineId;
     remoteLtpEngineId = o.remoteLtpEngineId;
@@ -262,11 +272,13 @@ induct_element_config_t& induct_element_config_t::operator=(induct_element_confi
 bool induct_element_config_t::operator==(const induct_element_config_t & o) const {
     return (name == o.name) &&
         (convergenceLayer == o.convergenceLayer) &&
-        (boundPort == o.boundPort) &&
-        (numRxCircularBufferElements == o.numRxCircularBufferElements) &&
-        (numRxCircularBufferBytesPerElement == o.numRxCircularBufferBytesPerElement) &&
+          (boundPort == o.boundPort) &&
+          (numRxCircularBufferElements == o.numRxCircularBufferElements) &&
+          (numRxCircularBufferBytesPerElement == o.numRxCircularBufferBytesPerElement) &&
 
-        (bpEncapLocalSocketOrPipePath == o.bpEncapLocalSocketOrPipePath) &&
+          (ramaHeaderByte == o.ramaHeaderByte) &&
+
+          (bpEncapLocalSocketOrPipePath == o.bpEncapLocalSocketOrPipePath) &&
 
         (thisLtpEngineId == o.thisLtpEngineId) &&
         (remoteLtpEngineId == o.remoteLtpEngineId) &&
@@ -382,14 +394,23 @@ bool InductsConfig::SetValuesFromPropertyTree(const boost::property_tree::ptree 
             { //no cb, relies on buffering from the local socket or pipe
                 inductElementConfig.numRxCircularBufferElements = inductElementConfigPt.second.get<uint32_t>("numRxCircularBufferElements");
             }
-            if ((inductElementConfig.convergenceLayer == "udp") || (inductElementConfig.convergenceLayer == "tcpcl_v3") || (inductElementConfig.convergenceLayer == "tcpcl_v4")) {
-                inductElementConfig.numRxCircularBufferBytesPerElement = inductElementConfigPt.second.get<uint32_t>("numRxCircularBufferBytesPerElement");
-            }
-            else if (inductElementConfigPt.second.count("numRxCircularBufferBytesPerElement")) { //not used by stcp or ltp
-                LOG_ERROR(subprocess) << "error parsing JSON inductVector[" << (vectorIndex - 1) << "]: convergence layer "
-                    << inductElementConfig.convergenceLayer << " induct config does not use numRxCircularBufferBytesPerElement.. please remove";
-                return false;
-            }
+              if ((inductElementConfig.convergenceLayer == "udp") || (inductElementConfig.convergenceLayer == "tcpcl_v3") || (inductElementConfig.convergenceLayer == "tcpcl_v4") || (inductElementConfig.convergenceLayer == "rama")) {
+                  inductElementConfig.numRxCircularBufferBytesPerElement = inductElementConfigPt.second.get<uint32_t>("numRxCircularBufferBytesPerElement");
+              }
+              else if (inductElementConfigPt.second.count("numRxCircularBufferBytesPerElement")) { //not used by stcp or ltp
+                  LOG_ERROR(subprocess) << "error parsing JSON inductVector[" << (vectorIndex - 1) << "]: convergence layer "
+                      << inductElementConfig.convergenceLayer << " induct config does not use numRxCircularBufferBytesPerElement.. please remove";
+                  return false;
+              }
+
+              if (inductElementConfig.convergenceLayer == "rama") {
+                  inductElementConfig.ramaHeaderByte = static_cast<uint8_t>(inductElementConfigPt.second.get<uint16_t>("ramaHeaderByte"));
+              }
+              else if (inductElementConfigPt.second.count("ramaHeaderByte") != 0) {
+                  LOG_ERROR(subprocess) << "error parsing JSON inductVector[" << (vectorIndex - 1) << "]: induct convergence layer  "
+                      << inductElementConfig.convergenceLayer << " has a rama induct only configuration parameter of \"ramaHeaderByte\".. please remove";
+                  return false;
+              }
 
             if ((inductElementConfig.convergenceLayer == "ltp_over_udp")
                 || (inductElementConfig.convergenceLayer == "ltp_over_ipc")
@@ -604,8 +625,11 @@ boost::property_tree::ptree InductsConfig::GetNewPropertyTree() const {
         { //no cb, relies on buffering from the local socket or pipe
             inductElementConfigPt.put("numRxCircularBufferElements", inductElementConfig.numRxCircularBufferElements);
         }
-        if ((inductElementConfig.convergenceLayer == "udp") || (inductElementConfig.convergenceLayer == "tcpcl_v3") || (inductElementConfig.convergenceLayer == "tcpcl_v4")) {
+        if ((inductElementConfig.convergenceLayer == "udp") || (inductElementConfig.convergenceLayer == "tcpcl_v3") || (inductElementConfig.convergenceLayer == "tcpcl_v4") || (inductElementConfig.convergenceLayer == "rama")) {
             inductElementConfigPt.put("numRxCircularBufferBytesPerElement", inductElementConfig.numRxCircularBufferBytesPerElement);
+        }
+        if (inductElementConfig.convergenceLayer == "rama") {
+            inductElementConfigPt.put("ramaHeaderByte", inductElementConfig.ramaHeaderByte);
         }
         if ((inductElementConfig.convergenceLayer == "ltp_over_udp")
             || (inductElementConfig.convergenceLayer == "ltp_over_ipc")

--- a/common/config/src/OutductsConfig.cpp
+++ b/common/config/src/OutductsConfig.cpp
@@ -26,7 +26,7 @@ static constexpr hdtn::Logger::SubProcess subprocess = hdtn::Logger::SubProcess:
 
 static const std::vector<std::string> VALID_CONVERGENCE_LAYER_NAMES = {
     "ltp_over_udp", "ltp_over_ipc", "ltp_over_encap_local_stream", "bp_over_encap_local_stream",
-    "udp", "stcp", "tcpcl_v3", "tcpcl_v4", "slip_over_uart"
+    "udp", "stcp", "tcpcl_v3", "tcpcl_v4", "slip_over_uart", "rama"
 };
 
 static const uint64_t DEFAULT_RATE_LIMIT_PRECISION = 100000;
@@ -57,13 +57,15 @@ outduct_element_config_t::outduct_element_config_t() :
     ltpMaxUdpPacketsToSendPerSystemCall(0),
     ltpSenderPingSecondsOrZeroToDisable(0),
     delaySendingOfDataSegmentsTimeMsOrZeroToDisable(20),
-    keepActiveSessionDataOnDisk(false),
-    activeSessionDataOnDiskNewFileDurationMs(2000),
-    activeSessionDataOnDiskDirectory("./"),
-    rateLimitPrecisionMicroSec(DEFAULT_RATE_LIMIT_PRECISION),
+      keepActiveSessionDataOnDisk(false),
+      activeSessionDataOnDiskNewFileDurationMs(2000),
+      activeSessionDataOnDiskDirectory("./"),
+      rateLimitPrecisionMicroSec(DEFAULT_RATE_LIMIT_PRECISION),
 
-    comPort(""),
-    baudRate(115200),
+      ramaHeaderByte(0xA0),
+
+      comPort(""),
+      baudRate(115200),
 
     keepAliveIntervalSeconds(0),
     tcpclV3MyMaxTxSegmentSizeBytes(0),
@@ -107,13 +109,15 @@ outduct_element_config_t::outduct_element_config_t(const outduct_element_config_
     ltpMaxUdpPacketsToSendPerSystemCall(o.ltpMaxUdpPacketsToSendPerSystemCall),
     ltpSenderPingSecondsOrZeroToDisable(o.ltpSenderPingSecondsOrZeroToDisable),
     delaySendingOfDataSegmentsTimeMsOrZeroToDisable(o.delaySendingOfDataSegmentsTimeMsOrZeroToDisable),
-    keepActiveSessionDataOnDisk(o.keepActiveSessionDataOnDisk),
-    activeSessionDataOnDiskNewFileDurationMs(o.activeSessionDataOnDiskNewFileDurationMs),
-    activeSessionDataOnDiskDirectory(o.activeSessionDataOnDiskDirectory),
-    rateLimitPrecisionMicroSec(o.rateLimitPrecisionMicroSec),
+      keepActiveSessionDataOnDisk(o.keepActiveSessionDataOnDisk),
+      activeSessionDataOnDiskNewFileDurationMs(o.activeSessionDataOnDiskNewFileDurationMs),
+      activeSessionDataOnDiskDirectory(o.activeSessionDataOnDiskDirectory),
+      rateLimitPrecisionMicroSec(o.rateLimitPrecisionMicroSec),
 
-    comPort(o.comPort),
-    baudRate(o.baudRate),
+      ramaHeaderByte(o.ramaHeaderByte),
+
+      comPort(o.comPort),
+      baudRate(o.baudRate),
 
     keepAliveIntervalSeconds(o.keepAliveIntervalSeconds),
     tcpclV3MyMaxTxSegmentSizeBytes(o.tcpclV3MyMaxTxSegmentSizeBytes),
@@ -154,13 +158,15 @@ outduct_element_config_t::outduct_element_config_t(outduct_element_config_t&& o)
     ltpMaxUdpPacketsToSendPerSystemCall(o.ltpMaxUdpPacketsToSendPerSystemCall),
     ltpSenderPingSecondsOrZeroToDisable(o.ltpSenderPingSecondsOrZeroToDisable),
     delaySendingOfDataSegmentsTimeMsOrZeroToDisable(o.delaySendingOfDataSegmentsTimeMsOrZeroToDisable),
-    keepActiveSessionDataOnDisk(o.keepActiveSessionDataOnDisk),
-    activeSessionDataOnDiskNewFileDurationMs(o.activeSessionDataOnDiskNewFileDurationMs),
-    activeSessionDataOnDiskDirectory(std::move(o.activeSessionDataOnDiskDirectory)),
-    rateLimitPrecisionMicroSec(o.rateLimitPrecisionMicroSec),
+      keepActiveSessionDataOnDisk(o.keepActiveSessionDataOnDisk),
+      activeSessionDataOnDiskNewFileDurationMs(o.activeSessionDataOnDiskNewFileDurationMs),
+      activeSessionDataOnDiskDirectory(std::move(o.activeSessionDataOnDiskDirectory)),
+      rateLimitPrecisionMicroSec(o.rateLimitPrecisionMicroSec),
 
-    comPort(std::move(o.comPort)),
-    baudRate(o.baudRate),
+      ramaHeaderByte(o.ramaHeaderByte),
+
+      comPort(std::move(o.comPort)),
+      baudRate(o.baudRate),
 
     keepAliveIntervalSeconds(o.keepAliveIntervalSeconds),
     tcpclV3MyMaxTxSegmentSizeBytes(o.tcpclV3MyMaxTxSegmentSizeBytes),
@@ -203,11 +209,13 @@ outduct_element_config_t& outduct_element_config_t::operator=(const outduct_elem
     delaySendingOfDataSegmentsTimeMsOrZeroToDisable = o.delaySendingOfDataSegmentsTimeMsOrZeroToDisable;
     keepActiveSessionDataOnDisk = o.keepActiveSessionDataOnDisk;
     activeSessionDataOnDiskNewFileDurationMs = o.activeSessionDataOnDiskNewFileDurationMs;
-    activeSessionDataOnDiskDirectory = o.activeSessionDataOnDiskDirectory;
-    rateLimitPrecisionMicroSec = o.rateLimitPrecisionMicroSec;
+      activeSessionDataOnDiskDirectory = o.activeSessionDataOnDiskDirectory;
+      rateLimitPrecisionMicroSec = o.rateLimitPrecisionMicroSec;
 
-    comPort = o.comPort;
-    baudRate = o.baudRate;
+      ramaHeaderByte = o.ramaHeaderByte;
+
+      comPort = o.comPort;
+      baudRate = o.baudRate;
 
     keepAliveIntervalSeconds = o.keepAliveIntervalSeconds;
 
@@ -253,11 +261,13 @@ outduct_element_config_t& outduct_element_config_t::operator=(outduct_element_co
     delaySendingOfDataSegmentsTimeMsOrZeroToDisable = o.delaySendingOfDataSegmentsTimeMsOrZeroToDisable;
     keepActiveSessionDataOnDisk = o.keepActiveSessionDataOnDisk;
     activeSessionDataOnDiskNewFileDurationMs = o.activeSessionDataOnDiskNewFileDurationMs;
-    activeSessionDataOnDiskDirectory = std::move(o.activeSessionDataOnDiskDirectory);
-    rateLimitPrecisionMicroSec = o.rateLimitPrecisionMicroSec;
+      activeSessionDataOnDiskDirectory = std::move(o.activeSessionDataOnDiskDirectory);
+      rateLimitPrecisionMicroSec = o.rateLimitPrecisionMicroSec;
 
-    comPort = std::move(o.comPort);
-    baudRate = o.baudRate;
+      ramaHeaderByte = o.ramaHeaderByte;
+
+      comPort = std::move(o.comPort);
+      baudRate = o.baudRate;
 
     keepAliveIntervalSeconds = o.keepAliveIntervalSeconds;
 
@@ -302,11 +312,13 @@ bool outduct_element_config_t::operator==(const outduct_element_config_t & o) co
         (delaySendingOfDataSegmentsTimeMsOrZeroToDisable == o.delaySendingOfDataSegmentsTimeMsOrZeroToDisable) &&
         (keepActiveSessionDataOnDisk == o.keepActiveSessionDataOnDisk) &&
         (activeSessionDataOnDiskNewFileDurationMs == o.activeSessionDataOnDiskNewFileDurationMs) &&
-        (activeSessionDataOnDiskDirectory == o.activeSessionDataOnDiskDirectory) &&
-        (rateLimitPrecisionMicroSec == o.rateLimitPrecisionMicroSec) &&
+          (activeSessionDataOnDiskDirectory == o.activeSessionDataOnDiskDirectory) &&
+          (rateLimitPrecisionMicroSec == o.rateLimitPrecisionMicroSec) &&
 
-        (comPort == o.comPort) &&
-        (baudRate == o.baudRate) &&
+          (ramaHeaderByte == o.ramaHeaderByte) &&
+
+          (comPort == o.comPort) &&
+          (baudRate == o.baudRate) &&
 
         (keepAliveIntervalSeconds == o.keepAliveIntervalSeconds) &&
         
@@ -401,8 +413,17 @@ bool OutductsConfig::SetValuesFromPropertyTree(const boost::property_tree::ptree
                     return false;
                 }
             }
-            outductElementConfig.maxNumberOfBundlesInPipeline = outductElementConfigPt.second.get<uint32_t>("maxNumberOfBundlesInPipeline");
-            outductElementConfig.maxSumOfBundleBytesInPipeline = outductElementConfigPt.second.get<uint64_t>("maxSumOfBundleBytesInPipeline");
+              outductElementConfig.maxNumberOfBundlesInPipeline = outductElementConfigPt.second.get<uint32_t>("maxNumberOfBundlesInPipeline");
+              outductElementConfig.maxSumOfBundleBytesInPipeline = outductElementConfigPt.second.get<uint64_t>("maxSumOfBundleBytesInPipeline");
+
+              if (outductElementConfig.convergenceLayer == "rama") {
+                  outductElementConfig.ramaHeaderByte = static_cast<uint8_t>(outductElementConfigPt.second.get<uint16_t>("ramaHeaderByte"));
+              }
+              else if (outductElementConfigPt.second.count("ramaHeaderByte") != 0) {
+                  LOG_ERROR(subprocess) << "error parsing JSON outductVector[" << (vectorIndex - 1) << "]: outduct convergence layer  "
+                      << outductElementConfig.convergenceLayer << " has a rama outduct only configuration parameter of \"ramaHeaderByte\".. please remove";
+                  return false;
+              }
 
             if ((outductElementConfig.convergenceLayer == "ltp_over_udp")
                 || (outductElementConfig.convergenceLayer == "ltp_over_ipc")
@@ -464,7 +485,7 @@ bool OutductsConfig::SetValuesFromPropertyTree(const boost::property_tree::ptree
                 }
             }
 
-            if (outductElementConfig.convergenceLayer == "ltp_over_udp" || outductElementConfig.convergenceLayer == "udp") {
+              if (outductElementConfig.convergenceLayer == "ltp_over_udp" || outductElementConfig.convergenceLayer == "udp" || outductElementConfig.convergenceLayer == "rama") {
                 outductElementConfig.rateLimitPrecisionMicroSec = outductElementConfigPt.second.get<uint64_t>("rateLimitPrecisionMicroSec", DEFAULT_RATE_LIMIT_PRECISION);
                 if (outductElementConfig.rateLimitPrecisionMicroSec == 0) {
                     LOG_ERROR(subprocess) << "error parsing JSON outductVector[" << (vectorIndex - 1) << "]: rateLimitPrecisionMicroSec " <<
@@ -472,7 +493,7 @@ bool OutductsConfig::SetValuesFromPropertyTree(const boost::property_tree::ptree
                         return false;
                 }
             }
-            else if (outductElementConfigPt.second.count("rateLimitPrecisionMicroSec")) {
+              else if (outductElementConfigPt.second.count("rateLimitPrecisionMicroSec")) {
                 LOG_ERROR(subprocess) << "error parsing JSON outductVector[" << (vectorIndex - 1) << "]: outduct convergence layer  " << outductElementConfig.convergenceLayer
                     << " has an ltp/udp outduct only configuration parameter of rateLimitPrecisionMicroSec .. please remove";
                 return false;
@@ -622,7 +643,11 @@ boost::property_tree::ptree OutductsConfig::GetNewPropertyTree() const {
             outductElementConfigPt.put("remotePort", outductElementConfig.remotePort);
         }
         outductElementConfigPt.put("maxNumberOfBundlesInPipeline", outductElementConfig.maxNumberOfBundlesInPipeline);
-        outductElementConfigPt.put("maxSumOfBundleBytesInPipeline", outductElementConfig.maxSumOfBundleBytesInPipeline);
+          outductElementConfigPt.put("maxSumOfBundleBytesInPipeline", outductElementConfig.maxSumOfBundleBytesInPipeline);
+
+          if (outductElementConfig.convergenceLayer == "rama") {
+              outductElementConfigPt.put("ramaHeaderByte", outductElementConfig.ramaHeaderByte);
+          }
         
         if ((outductElementConfig.convergenceLayer == "ltp_over_udp")
             || (outductElementConfig.convergenceLayer == "ltp_over_ipc")
@@ -653,7 +678,7 @@ boost::property_tree::ptree OutductsConfig::GetNewPropertyTree() const {
             outductElementConfigPt.put("activeSessionDataOnDiskNewFileDurationMs", outductElementConfig.activeSessionDataOnDiskNewFileDurationMs);
             outductElementConfigPt.put("activeSessionDataOnDiskDirectory", outductElementConfig.activeSessionDataOnDiskDirectory.string()); //.string() prevents nested quotes in json file
         }
-        if ((outductElementConfig.convergenceLayer == "ltp_over_udp") || (outductElementConfig.convergenceLayer == "udp")) {
+          if ((outductElementConfig.convergenceLayer == "ltp_over_udp") || (outductElementConfig.convergenceLayer == "udp") || (outductElementConfig.convergenceLayer == "rama")) {
             outductElementConfigPt.put("rateLimitPrecisionMicroSec", outductElementConfig.rateLimitPrecisionMicroSec);
         }
         if (outductElementConfig.convergenceLayer == "bp_over_encap_local_stream") {

--- a/common/induct_manager/CMakeLists.txt
+++ b/common/induct_manager/CMakeLists.txt
@@ -3,9 +3,10 @@ add_library(induct_manager_lib
 	src/Induct.cpp
 	src/TcpclInduct.cpp
 	src/TcpclV4Induct.cpp
-	src/StcpInduct.cpp
+        src/StcpInduct.cpp
     src/UdpInduct.cpp
-	src/LtpInduct.cpp
+        src/RamaInduct.cpp
+        src/LtpInduct.cpp
 	src/LtpOverEncapLocalStreamInduct.cpp
 	src/LtpOverIpcInduct.cpp
 	src/LtpOverUdpInduct.cpp
@@ -27,11 +28,12 @@ set(MY_PUBLIC_HEADERS
 	include/LtpOverIpcInduct.h
 	include/LtpOverUdpInduct.h
 	include/SlipOverUartInduct.h
-	include/StcpInduct.h
-	include/TcpclInduct.h
-	include/TcpclV4Induct.h
-	include/UdpInduct.h
-	${CMAKE_CURRENT_BINARY_DIR}/induct_manager_lib_export.h
+        include/StcpInduct.h
+        include/TcpclInduct.h
+        include/TcpclV4Induct.h
+        include/UdpInduct.h
+        include/RamaInduct.h
+        ${CMAKE_CURRENT_BINARY_DIR}/induct_manager_lib_export.h
 )
 set_target_properties(induct_manager_lib PROPERTIES PUBLIC_HEADER "${MY_PUBLIC_HEADERS}") # this needs to be a list, so putting in quotes makes it a ; separated list
 target_link_libraries(induct_manager_lib

--- a/common/induct_manager/include/RamaInduct.h
+++ b/common/induct_manager/include/RamaInduct.h
@@ -1,0 +1,25 @@
+#ifndef RAMA_INDUCT_H
+#define RAMA_INDUCT_H 1
+
+#include <string>
+#include "Induct.h"
+#include "UdpBundleSink.h"
+#include <memory>
+
+class CLASS_VISIBILITY_INDUCT_MANAGER_LIB RamaInduct : public Induct {
+public:
+    INDUCT_MANAGER_LIB_EXPORT RamaInduct(const InductProcessBundleCallback_t & inductProcessBundleCallback, const induct_element_config_t & inductConfig);
+    INDUCT_MANAGER_LIB_EXPORT virtual ~RamaInduct() override;
+    INDUCT_MANAGER_LIB_EXPORT virtual void PopulateInductTelemetry(InductTelemetry_t& inductTelem) override;
+private:
+    RamaInduct();
+    INDUCT_MANAGER_LIB_EXPORT void HandleRamaBundle(padded_vector_uint8_t & bundle);
+    INDUCT_MANAGER_LIB_EXPORT void ConnectionReadyToBeDeletedNotificationReceived();
+    INDUCT_MANAGER_LIB_EXPORT void RemoveInactiveConnection();
+
+    boost::asio::io_service m_ioService;
+    std::unique_ptr<boost::thread> m_ioServiceThreadPtr;
+    std::unique_ptr<UdpBundleSink> m_udpBundleSinkPtr;
+};
+
+#endif // RAMA_INDUCT_H

--- a/common/induct_manager/src/InductManager.cpp
+++ b/common/induct_manager/src/InductManager.cpp
@@ -20,6 +20,7 @@
 #include "TcpclV4Induct.h"
 #include "StcpInduct.h"
 #include "UdpInduct.h"
+#include "RamaInduct.h"
 #include "LtpOverUdpInduct.h"
 #include "LtpOverIpcInduct.h"
 #include "LtpOverEncapLocalStreamInduct.h"
@@ -68,6 +69,9 @@ bool InductManager::LoadInductsFromConfig(const InductProcessBundleCallback_t & 
         }
         else if (thisInductConfig.convergenceLayer == "udp") {
             m_inductsList.emplace_back(boost::make_unique<UdpInduct>(inductProcessBundleCallback, thisInductConfig));
+        }
+        else if (thisInductConfig.convergenceLayer == "rama") {
+            m_inductsList.emplace_back(boost::make_unique<RamaInduct>(inductProcessBundleCallback, thisInductConfig));
         }
         else if (thisInductConfig.convergenceLayer == "ltp_over_udp") {
             m_inductsList.emplace_back(boost::make_unique<LtpOverUdpInduct>(inductProcessBundleCallback, thisInductConfig, maxBundleSizeBytes));

--- a/common/induct_manager/src/RamaInduct.cpp
+++ b/common/induct_manager/src/RamaInduct.cpp
@@ -1,0 +1,67 @@
+#include "RamaInduct.h"
+#include "Logger.h"
+#include <iostream>
+#include <boost/make_unique.hpp>
+#include <memory>
+#include <boost/bind/bind.hpp>
+#include "ThreadNamer.h"
+
+using boost::placeholders::_1;
+
+static constexpr hdtn::Logger::SubProcess subprocess = hdtn::Logger::SubProcess::none;
+
+RamaInduct::RamaInduct(const InductProcessBundleCallback_t & inductProcessBundleCallback, const induct_element_config_t & inductConfig) :
+    Induct(inductProcessBundleCallback, inductConfig) {
+
+    m_udpBundleSinkPtr = boost::make_unique<UdpBundleSink>(m_ioService, inductConfig.boundPort,
+        boost::bind(&RamaInduct::HandleRamaBundle, this, _1),
+        m_inductConfig.numRxCircularBufferElements,
+        m_inductConfig.numRxCircularBufferBytesPerElement,
+        boost::bind(&RamaInduct::ConnectionReadyToBeDeletedNotificationReceived, this));
+
+    m_ioServiceThreadPtr = boost::make_unique<boost::thread>(boost::bind(&boost::asio::io_service::run, &m_ioService));
+    ThreadNamer::SetIoServiceThreadName(m_ioService, "ioServiceRamaInduct");
+}
+
+RamaInduct::~RamaInduct() {
+    m_udpBundleSinkPtr.reset();
+    if (m_ioServiceThreadPtr) {
+        try {
+            m_ioServiceThreadPtr->join();
+            m_ioServiceThreadPtr.reset();
+        }
+        catch (const boost::thread_resource_error&) {
+            LOG_ERROR(subprocess) << "error stopping RamaInduct io_service";
+        }
+    }
+}
+
+void RamaInduct::HandleRamaBundle(padded_vector_uint8_t & bundle) {
+    if (!bundle.empty()) {
+        if (bundle[0] == m_inductConfig.ramaHeaderByte) {
+            bundle.erase(bundle.begin()); // remove header byte
+            m_inductProcessBundleCallback(bundle);
+        } else {
+            LOG_ERROR(subprocess) << "unexpected rama header byte " << static_cast<int>(bundle[0])
+                                  << " expected " << static_cast<int>(m_inductConfig.ramaHeaderByte);
+        }
+    }
+}
+
+void RamaInduct::RemoveInactiveConnection() {
+    if (m_udpBundleSinkPtr && m_udpBundleSinkPtr->ReadyToBeDeleted()) {
+        m_udpBundleSinkPtr.reset();
+    }
+}
+
+void RamaInduct::ConnectionReadyToBeDeletedNotificationReceived() {
+    boost::asio::post(m_ioService, boost::bind(&RamaInduct::RemoveInactiveConnection, this));
+}
+
+void RamaInduct::PopulateInductTelemetry(InductTelemetry_t& inductTelem) {
+    inductTelem.m_convergenceLayer = "rama";
+    inductTelem.m_listInductConnections.clear();
+    std::unique_ptr<UdpInductConnectionTelemetry_t> t = boost::make_unique<UdpInductConnectionTelemetry_t>();
+    m_udpBundleSinkPtr->GetTelemetry(*t);
+    inductTelem.m_listInductConnections.emplace_back(std::move(t));
+}

--- a/common/outduct_manager/CMakeLists.txt
+++ b/common/outduct_manager/CMakeLists.txt
@@ -2,9 +2,10 @@ add_library(outduct_manager_lib
 	src/Outduct.cpp
 	src/TcpclOutduct.cpp
 	src/TcpclV4Outduct.cpp
-	src/StcpOutduct.cpp
+        src/StcpOutduct.cpp
     src/UdpOutduct.cpp
-	src/LtpOutduct.cpp
+        src/RamaOutduct.cpp
+        src/LtpOutduct.cpp
 	src/LtpOverEncapLocalStreamOutduct.cpp
 	src/LtpOverIpcOutduct.cpp
 	src/LtpOverUdpOutduct.cpp
@@ -24,12 +25,13 @@ set(MY_PUBLIC_HEADERS
     include/LtpOverUdpOutduct.h
 	include/LtpOutduct.h
 	include/Outduct.h
-	include/OutductManager.h
-	include/StcpOutduct.h
-	include/TcpclOutduct.h
-	include/TcpclV4Outduct.h
-	include/UdpOutduct.h
-	include/SlipOverUartOutduct.h
+        include/OutductManager.h
+        include/StcpOutduct.h
+        include/TcpclOutduct.h
+        include/TcpclV4Outduct.h
+        include/UdpOutduct.h
+        include/RamaOutduct.h
+        include/SlipOverUartOutduct.h
 	include/BpOverEncapLocalStreamOutduct.h
 	${CMAKE_CURRENT_BINARY_DIR}/outduct_manager_lib_export.h
 )

--- a/common/outduct_manager/include/RamaOutduct.h
+++ b/common/outduct_manager/include/RamaOutduct.h
@@ -1,0 +1,37 @@
+#ifndef RAMA_OUTDUCT_H
+#define RAMA_OUTDUCT_H 1
+
+#include <string>
+#include "Outduct.h"
+#include "UdpBundleSource.h"
+#include <list>
+
+class CLASS_VISIBILITY_OUTDUCT_MANAGER_LIB RamaOutduct : public Outduct {
+public:
+    OUTDUCT_MANAGER_LIB_EXPORT RamaOutduct(const outduct_element_config_t & outductConfig, const uint64_t outductUuid);
+    OUTDUCT_MANAGER_LIB_EXPORT virtual ~RamaOutduct() override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void PopulateOutductTelemetry(std::unique_ptr<OutductTelemetry_t>& outductTelem) override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual std::size_t GetTotalBundlesUnacked() const noexcept override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual bool Forward(const uint8_t* bundleData, const std::size_t size, std::vector<uint8_t>&& userData) override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual bool Forward(zmq::message_t & movableDataZmq, std::vector<uint8_t>&& userData) override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual bool Forward(padded_vector_uint8_t& movableDataVec, std::vector<uint8_t>&& userData) override;
+
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void SetOnFailedBundleVecSendCallback(const OnFailedBundleVecSendCallback_t& callback) override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void SetOnFailedBundleZmqSendCallback(const OnFailedBundleZmqSendCallback_t& callback) override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void SetOnSuccessfulBundleSendCallback(const OnSuccessfulBundleSendCallback_t& callback) override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void SetOnOutductLinkStatusChangedCallback(const OnOutductLinkStatusChangedCallback_t& callback) override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void SetUserAssignedUuid(uint64_t userAssignedUuid) override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void SetRate(uint64_t maxSendRateBitsPerSecOrZeroToDisable) override;
+
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void Connect() override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual bool ReadyToForward() override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void Stop() override;
+    OUTDUCT_MANAGER_LIB_EXPORT virtual void GetOutductFinalStats(OutductFinalStats & finalStats) override;
+
+private:
+    RamaOutduct();
+
+    UdpBundleSource m_udpBundleSource;
+};
+
+#endif // RAMA_OUTDUCT_H

--- a/common/outduct_manager/src/OutductManager.cpp
+++ b/common/outduct_manager/src/OutductManager.cpp
@@ -20,6 +20,7 @@
 #include "TcpclV4Outduct.h"
 #include "StcpOutduct.h"
 #include "UdpOutduct.h"
+#include "RamaOutduct.h"
 #include "LtpOverUdpOutduct.h"
 #include "LtpOverIpcOutduct.h"
 #include "LtpOverEncapLocalStreamOutduct.h"
@@ -105,6 +106,9 @@ bool OutductManager::LoadOutductsFromConfig(const OutductsConfig & outductsConfi
         }
         else if (thisOutductConfig.convergenceLayer == "udp") {
             outductSharedPtr = std::make_shared<UdpOutduct>(thisOutductConfig, uuidIndex);
+        }
+        else if (thisOutductConfig.convergenceLayer == "rama") {
+            outductSharedPtr = std::make_shared<RamaOutduct>(thisOutductConfig, uuidIndex);
         }
         else if (thisOutductConfig.convergenceLayer == "ltp_over_udp") {
             outductSharedPtr = std::make_shared<LtpOverUdpOutduct>(thisOutductConfig, uuidIndex);

--- a/common/outduct_manager/src/RamaOutduct.cpp
+++ b/common/outduct_manager/src/RamaOutduct.cpp
@@ -1,0 +1,79 @@
+#include "RamaOutduct.h"
+#include <boost/make_unique.hpp>
+#include <memory>
+#include <boost/lexical_cast.hpp>
+#include <cstring>
+
+RamaOutduct::RamaOutduct(const outduct_element_config_t & outductConfig, const uint64_t outductUuid) :
+    Outduct(outductConfig, outductUuid, false),
+    m_udpBundleSource(outductConfig.maxNumberOfBundlesInPipeline + 5, outductConfig.rateLimitPrecisionMicroSec) {}
+
+RamaOutduct::~RamaOutduct() {}
+
+std::size_t RamaOutduct::GetTotalBundlesUnacked() const noexcept {
+    return m_udpBundleSource.GetTotalUdpPacketsUnacked();
+}
+
+bool RamaOutduct::Forward(const uint8_t* bundleData, const std::size_t size, std::vector<uint8_t>&& userData) {
+    padded_vector_uint8_t data(size + 1);
+    data[0] = m_outductConfig.ramaHeaderByte;
+    if (size > 0) {
+        std::memcpy(data.data() + 1, bundleData, size);
+    }
+    return m_udpBundleSource.Forward(data, std::move(userData));
+}
+
+bool RamaOutduct::Forward(zmq::message_t & movableDataZmq, std::vector<uint8_t>&& userData) {
+    zmq::message_t data(movableDataZmq.size() + 1);
+    uint8_t* ptr = static_cast<uint8_t*>(data.data());
+    ptr[0] = m_outductConfig.ramaHeaderByte;
+    if (movableDataZmq.size() > 0) {
+        std::memcpy(ptr + 1, movableDataZmq.data(), movableDataZmq.size());
+    }
+    return m_udpBundleSource.Forward(data, std::move(userData));
+}
+
+bool RamaOutduct::Forward(padded_vector_uint8_t& movableDataVec, std::vector<uint8_t>&& userData) {
+    movableDataVec.insert(movableDataVec.begin(), m_outductConfig.ramaHeaderByte);
+    return m_udpBundleSource.Forward(movableDataVec, std::move(userData));
+}
+
+void RamaOutduct::SetOnFailedBundleVecSendCallback(const OnFailedBundleVecSendCallback_t& callback) {
+    m_udpBundleSource.SetOnFailedBundleVecSendCallback(callback);
+}
+void RamaOutduct::SetOnFailedBundleZmqSendCallback(const OnFailedBundleZmqSendCallback_t& callback) {
+    m_udpBundleSource.SetOnFailedBundleZmqSendCallback(callback);
+}
+void RamaOutduct::SetOnSuccessfulBundleSendCallback(const OnSuccessfulBundleSendCallback_t& callback) {
+    m_udpBundleSource.SetOnSuccessfulBundleSendCallback(callback);
+}
+void RamaOutduct::SetOnOutductLinkStatusChangedCallback(const OnOutductLinkStatusChangedCallback_t& callback) {
+    m_udpBundleSource.SetOnOutductLinkStatusChangedCallback(callback);
+}
+void RamaOutduct::SetUserAssignedUuid(uint64_t userAssignedUuid) {
+    m_udpBundleSource.SetUserAssignedUuid(userAssignedUuid);
+}
+void RamaOutduct::SetRate(uint64_t maxSendRateBitsPerSecOrZeroToDisable) {
+    m_udpBundleSource.UpdateRate(maxSendRateBitsPerSecOrZeroToDisable);
+}
+
+void RamaOutduct::Connect() {
+    m_udpBundleSource.Connect(m_outductConfig.remoteHostname, boost::lexical_cast<std::string>(m_outductConfig.remotePort));
+}
+bool RamaOutduct::ReadyToForward() {
+    return m_udpBundleSource.ReadyToForward();
+}
+void RamaOutduct::Stop() {
+    m_udpBundleSource.Stop();
+}
+void RamaOutduct::GetOutductFinalStats(OutductFinalStats & finalStats) {
+    finalStats.m_convergenceLayer = m_outductConfig.convergenceLayer;
+    finalStats.m_totalBundlesAcked = m_udpBundleSource.GetTotalUdpPacketsAcked();
+    finalStats.m_totalBundlesSent = m_udpBundleSource.GetTotalUdpPacketsSent();
+}
+void RamaOutduct::PopulateOutductTelemetry(std::unique_ptr<OutductTelemetry_t>& outductTelem) {
+    std::unique_ptr<UdpOutductTelemetry_t> t = boost::make_unique<UdpOutductTelemetry_t>();
+    m_udpBundleSource.GetTelemetry(*t);
+    outductTelem = std::move(t);
+    outductTelem->m_linkIsUpPerTimeSchedule = m_linkIsUpPerTimeSchedule;
+}

--- a/config_files/hdtn/hdtn_ingress1rama_port4556_egress1rama_port4558_header161.json
+++ b/config_files/hdtn/hdtn_ingress1rama_port4556_egress1rama_port4558_header161.json
@@ -1,0 +1,68 @@
+{
+    "hdtnConfigName": "rama example",
+    "userInterfaceOn": true,
+    "mySchemeName": "unused_scheme_name",
+    "myNodeId": 10,
+    "myBpEchoServiceId": 2047,
+    "myCustodialSsp": "unused_custodial_ssp",
+    "myCustodialServiceId": 0,
+    "myRouterServiceId": 100,
+    "isAcsAware": true,
+    "acsMaxFillsPerAcsPacket": 100,
+    "acsSendPeriodMilliseconds": 1000,
+    "retransmitBundleAfterNoCustodySignalMilliseconds": 10000,
+    "maxBundleSizeBytes": 10000000,
+    "maxIngressBundleWaitOnEgressMilliseconds": 2000,
+    "bufferRxToStorageOnLinkUpSaturation": false,
+    "maxLtpReceiveUdpPacketSizeBytes": 65536,
+    "neighborDepletedStorageDelaySeconds": 0,
+    "fragmentBundlesLargerThanBytes": 0,
+    "enforceBundlePriority": false,
+    "zmqBoundRouterPubSubPortPath": 10200,
+    "zmqBoundTelemApiPortPath": 10305,
+    "inductsConfig": {
+        "inductConfigName": "myconfig",
+        "inductVector": [
+            {
+                "name": "rama_ingress",
+                "convergenceLayer": "rama",
+                "boundPort": 4556,
+                "numRxCircularBufferElements": 2000,
+                "numRxCircularBufferBytesPerElement": 65535,
+                "ramaHeaderByte": 161
+            }
+        ]
+    },
+    "outductsConfig": {
+        "outductConfigName": "myconfig",
+        "outductVector": [
+            {
+                "name": "rama_egress",
+                "convergenceLayer": "rama",
+                "nextHopNodeId": 2,
+                "remoteHostname": "localhost",
+                "remotePort": 4558,
+                "maxNumberOfBundlesInPipeline": 50,
+                "maxSumOfBundleBytesInPipeline": 50000000,
+                "ramaHeaderByte": 161
+            }
+        ]
+    },
+    "storageConfig": {
+        "storageImplementation": "asio_single_threaded",
+        "tryToRestoreFromDisk": false,
+        "autoDeleteFilesOnExit": true,
+        "totalStorageCapacityBytes": 8192000000,
+        "storageDeletionPolicy": "never",
+        "storageDiskConfigVector": [
+            {
+                "name": "d1",
+                "storeFilePath": "./store1.bin"
+            },
+            {
+                "name": "d2",
+                "storeFilePath": "./store2.bin"
+            }
+        ]
+    }
+}

--- a/config_files/inducts/bpsink_one_rama_port4558_header161.json
+++ b/config_files/inducts/bpsink_one_rama_port4558_header161.json
@@ -1,0 +1,13 @@
+{
+    "inductConfigName": "myconfig",
+    "inductVector": [
+        {
+            "name": "rama_bpsink",
+            "convergenceLayer": "rama",
+            "boundPort": 4558,
+            "numRxCircularBufferElements": 2000,
+            "numRxCircularBufferBytesPerElement": 65535,
+            "ramaHeaderByte": 161
+        }
+    ]
+}

--- a/config_files/outducts/bpgen_one_rama_port4556_header161.json
+++ b/config_files/outducts/bpgen_one_rama_port4556_header161.json
@@ -1,0 +1,15 @@
+{
+    "outductConfigName": "myconfig",
+    "outductVector": [
+        {
+            "name": "bpgen",
+            "convergenceLayer": "rama",
+            "nextHopNodeId": 10,
+            "remoteHostname": "localhost",
+            "remotePort": 4556,
+            "maxNumberOfBundlesInPipeline": 5,
+            "maxSumOfBundleBytesInPipeline": 50000000,
+            "ramaHeaderByte": 161
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Implemented simple `rama` convergence layer using UDP sockets that prepends a header byte to each bundle and strips it on reception
- Integrated `rama` outduct and induct into managers and build configuration
- Added `ramaHeaderByte` configuration parameter and example configs for customizing the header byte

## Testing
- `sudo apt-get update` *(fails: 403  Forbidden)*
- `mkdir -p build && cd build && cmake ..` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_689c71e430c083278495136deac5beba