### PR TITLE
Add missing Hilink CMake config template

### DIFF
--- a/common/hilink/HilinkLibConfig.cmake.in
+++ b/common/hilink/HilinkLibConfig.cmake.in
@@ -1,0 +1,11 @@
+get_filename_component(HILINKLIB_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(CMakeFindDependencyMacro)
+
+find_dependency(StcpLib REQUIRED)
+find_dependency(LoggerLib REQUIRED)
+
+if(NOT TARGET HDTN::HilinkLib)
+    include("${HILINKLIB_CMAKE_DIR}/HilinkLibTargets.cmake")
+endif()
+
+set(HILINKLIB_LIBRARIES HDTN::HilinkLib)


### PR DESCRIPTION
## Summary
- add the missing HilinkLibConfig.cmake.in template so the Hilink library can be exported like the other libraries
- ensure the Hilink package config locates the Logger and STCP dependencies before including its exported targets

## Testing
- `cmake -S . -B build` *(fails: Boost 1.66+ not found in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de593d634832787ff36ce9b91a741)