### PR TITLE
Fix Hilink callback type definitions

### DIFF
--- a/common/hilink/include/HilinkTcpBundleSource.h
+++ b/common/hilink/include/HilinkTcpBundleSource.h
@@ -21,10 +21,10 @@ public:
     HILINK_LIB_EXPORT bool Forward(zmq::message_t & movableDataZmq, std::vector<uint8_t>&& userData);
     HILINK_LIB_EXPORT bool Forward(padded_vector_uint8_t& movableDataVec, std::vector<uint8_t>&& userData);
 
-    HILINK_LIB_EXPORT void SetOnFailedBundleVecSendCallback(const StcpBundleSource::OnFailedBundleVecSendCallback_t& callback);
-    HILINK_LIB_EXPORT void SetOnFailedBundleZmqSendCallback(const StcpBundleSource::OnFailedBundleZmqSendCallback_t& callback);
-    HILINK_LIB_EXPORT void SetOnSuccessfulBundleSendCallback(const StcpBundleSource::OnSuccessfulBundleSendCallback_t& callback);
-    HILINK_LIB_EXPORT void SetOnOutductLinkStatusChangedCallback(const StcpBundleSource::OnOutductLinkStatusChangedCallback_t& callback);
+    HILINK_LIB_EXPORT void SetOnFailedBundleVecSendCallback(const OnFailedBundleVecSendCallback_t& callback);
+    HILINK_LIB_EXPORT void SetOnFailedBundleZmqSendCallback(const OnFailedBundleZmqSendCallback_t& callback);
+    HILINK_LIB_EXPORT void SetOnSuccessfulBundleSendCallback(const OnSuccessfulBundleSendCallback_t& callback);
+    HILINK_LIB_EXPORT void SetOnOutductLinkStatusChangedCallback(const OnOutductLinkStatusChangedCallback_t& callback);
     HILINK_LIB_EXPORT void SetUserAssignedUuid(uint64_t userAssignedUuid);
 
     HILINK_LIB_EXPORT void Connect(const std::string & hostname, const std::string & port);

--- a/common/hilink/src/HilinkTcpBundleSource.cpp
+++ b/common/hilink/src/HilinkTcpBundleSource.cpp
@@ -42,19 +42,19 @@ bool HilinkTcpBundleSource::ForwardVector(padded_vector_uint8_t& data, std::vect
     return m_stcpBundleSource.Forward(data, std::move(userData));
 }
 
-void HilinkTcpBundleSource::SetOnFailedBundleVecSendCallback(const StcpBundleSource::OnFailedBundleVecSendCallback_t& callback) {
+void HilinkTcpBundleSource::SetOnFailedBundleVecSendCallback(const OnFailedBundleVecSendCallback_t& callback) {
     m_stcpBundleSource.SetOnFailedBundleVecSendCallback(callback);
 }
 
-void HilinkTcpBundleSource::SetOnFailedBundleZmqSendCallback(const StcpBundleSource::OnFailedBundleZmqSendCallback_t& callback) {
+void HilinkTcpBundleSource::SetOnFailedBundleZmqSendCallback(const OnFailedBundleZmqSendCallback_t& callback) {
     m_stcpBundleSource.SetOnFailedBundleZmqSendCallback(callback);
 }
 
-void HilinkTcpBundleSource::SetOnSuccessfulBundleSendCallback(const StcpBundleSource::OnSuccessfulBundleSendCallback_t& callback) {
+void HilinkTcpBundleSource::SetOnSuccessfulBundleSendCallback(const OnSuccessfulBundleSendCallback_t& callback) {
     m_stcpBundleSource.SetOnSuccessfulBundleSendCallback(callback);
 }
 
-void HilinkTcpBundleSource::SetOnOutductLinkStatusChangedCallback(const StcpBundleSource::OnOutductLinkStatusChangedCallback_t& callback) {
+void HilinkTcpBundleSource::SetOnOutductLinkStatusChangedCallback(const OnOutductLinkStatusChangedCallback_t& callback) {
     m_stcpBundleSource.SetOnOutductLinkStatusChangedCallback(callback);
 }
 


### PR DESCRIPTION
## Summary
- use common bundle callback typedefs in HilinkTcpBundleSource declarations and definitions

## Testing
- cmake -S . -B build -DDO_STATS_LOGGING=ON *(fails: Boost dependency not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5aed014c8327a663ef33c7397603)